### PR TITLE
feature:kakao login

### DIFF
--- a/TerraBox/settings.py
+++ b/TerraBox/settings.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -58,7 +59,6 @@ MIDDLEWARE = [
     # 'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'corsheaders.middleware.CorsMiddleware'
 ]
 
 ROOT_URLCONF = 'TerraBox.urls'

--- a/TerraBox/urls.py
+++ b/TerraBox/urls.py
@@ -2,4 +2,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('movies', include('movies.urls')),
+    path('users',include('users.urls')),
 ]

--- a/reservations/views.py
+++ b/reservations/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,37 @@
-from django.test import TestCase
+from django.test import TestCase,Client
+from django.unittest import mock,patch
+import json, bcrypt
 
-# Create your tests here.
+@patch('users.views.requests') #users.views에 등장하는 모든 requests의 값을 magicmock이라는 객체로 바꿔줌
+def test_success_kakaologin(self,mocked_requests):
+    client = Client()
+
+    class MockedResponse:
+        def json(self):
+            return {
+    "id": 2239940166,
+    "connected_at": "2022-05-12T16:57:36Z",
+    "properties": {
+        "nickname": "김영빈"
+    },
+    "kakao_account": {
+        "profile_nickname_needs_agreement": false,
+        "profile_image_needs_agreement": false,
+        "profile": {
+            "nickname": "김영빈",
+            "thumbnail_image_url": "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_110x110.jpg",
+            "profile_image_url": "http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg",
+            "is_default_image": true
+        },
+        "has_email": true,
+        "email_needs_agreement": false,
+        "is_email_valid": true,
+        "is_email_verified": true,
+        "email": "colock123@gmail.com"
+    }
+}
+    mocked_requests.get = MagicMock(return_value=MockedResponse())
+    #users.views.requests대신에 mocked_requests라는 게 들어가고,
+    #mocked_requests.get에 Mockedresponse가 들어간다
+    #mockedResponse는 결국 mockedResponse.json()와 같은 식으로 호출될 꺼니까, json함수를 넣어준 것임
+    

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,4 +1,6 @@
 from django.urls import path
+from .views import KakaoLoginView
 
 urlpatterns = [
+    path('/login',KakaoLoginView.as_view())
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,52 @@
-from django.shortcuts import render
+import json, jwt, requests
 
-# Create your views here.
+from django.http       import JsonResponse
+from django.views      import View
+from datetime          import datetime,timedelta
+from TerraBox.settings import ALGORITHM,SECRET_KEY
+
+from users.models import User
+
+def get_kakao_info(token):
+    kakao_url = "https://kapi.kakao.com/v2/user/me"
+    header ={
+        "Content-Type"  : "application/x-www-form-urlencoded",
+        "Authorization" : token,
+    }
+
+    return requests.get(kakao_url,headers=header).json()
+
+class KakaoLoginView(View):
+
+    def post(self,request):
+        try:
+            token = f"Bearer {request.headers.get('Authorization')}"
+
+            response          = get_kakao_info(token)
+            kakao_id          = response.get('id')
+            nickname          = response.get('properties').get('nickname')
+            profile_image_url = response.get('kakao_account').get('profile').get('thumbnail_image_url')
+            email             = response.get('kakao_account').get('email')
+            
+            user,created = User.objects.get_or_create(
+                kakao_id=kakao_id, 
+                defaults = {
+                    "nickname"         :nickname,
+                    "profile_image_url":profile_image_url,
+                    "email"            :email,
+                }
+            )
+
+            expiration = timedelta(seconds=3600)
+            token_expiration_time = datetime.utcnow() + expiration
+            
+            jwt_access_token = jwt.encode({'id':user.id,'exp':token_expiration_time},SECRET_KEY,algorithm=ALGORITHM)
+
+            return JsonResponse({'message':'success!',
+            'JWT_ACCESS_TOKEN':jwt_access_token,
+            "profile_image_url":user.profile_image_url,
+            "nickname":user.nickname,
+            "email":user.email},status=201)
+
+        except KeyError:
+            return JsonResponse({'message':'KEY_ERROR'},status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 아이디, 비밀번호 입력창을 사용한 로그인 기능 구현 (예시)

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 소셜 로그인
-프론트로 부터 토큰을 받아 정보를 저장 / 로그인


기타 질문 및 특이 사항
- 아이디가 있는지 확인하고 없을 경우 생성하는 로직에서 get_or_create를 쓰고 싶었는데, 이러한 방식으로 객체가 생성될 경우 id가 1,2,3,4,5같은 정수가 아니라 kkaoid가 들어갑니다. 해결방법이 있을까요?
